### PR TITLE
Sync sndio backend with OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,7 @@ PULSEAUDIO_VARS_OFF=	GN_ARGS+=use_pulseaudio=false
 
 # With SNDIO=on we exclude audio_manager_linux from the build (see
 # media/audio/BUILD.gn) and use audio_manager_openbsd which does not
-# support falling back to ALSA.  In theory it supports falling back to
-# PulseAudio, but this is untested.
+# support falling back to ALSA or PulseAudio.
 SNDIO_PREVENTS=		ALSA PULSEAUDIO
 SNDIO_LIB_DEPENDS=	libsndio.so:audio/sndio
 SNDIO_VARS=		GN_ARGS+=use_sndio=true

--- a/files/audio_manager_openbsd.h
+++ b/files/audio_manager_openbsd.h
@@ -17,10 +17,9 @@ namespace media {
 
 class MEDIA_EXPORT AudioManagerOpenBSD : public AudioManagerBase {
  public:
-  AudioManagerOpenBSD(
-      scoped_refptr<base::SingleThreadTaskRunner> task_runner,
-      scoped_refptr<base::SingleThreadTaskRunner> worker_task_runner,
-      AudioLogFactory* audio_log_factory);
+  AudioManagerOpenBSD(std::unique_ptr<AudioThread> audio_thread,
+                   AudioLogFactory* audio_log_factory);
+  ~AudioManagerOpenBSD() override;
 
   // Implementation of AudioManager.
   bool HasAudioOutputDevices() override;
@@ -50,8 +49,6 @@ class MEDIA_EXPORT AudioManagerOpenBSD : public AudioManagerBase {
       const LogCallback& log_callback) override;
 
  protected:
-  ~AudioManagerOpenBSD() override;
-
   AudioParameters GetPreferredOutputStreamParameters(
       const std::string& output_device_id,
       const AudioParameters& input_params) override;


### PR DESCRIPTION
There were some changes to the AudioManager between Chromium 59.0.3071.115 and 60.0.3112.90 [1] and the sndio backend fails to build.

```../../media/audio/openbsd/audio_manager_openbsd.cc:89:7: error: no matching constructor for initialization of 'media::AudioManagerBase'
    : AudioManagerBase(std::move(task_runner),
      ^                ~~~~~~~~~~~~~~~~~~~~~~~
../../media/audio/audio_manager_base.h:98:3: note: candidate constructor not viable: requires 2 arguments, but 3 were provided
  AudioManagerBase(std::unique_ptr<AudioThread> audio_thread,
  ^
../../media/audio/audio_manager_base.h:201:28: note: candidate constructor not viable: requires 1 argument, but 3 were provided
  DISALLOW_COPY_AND_ASSIGN(AudioManagerBase);
                           ^
../../media/audio/openbsd/audio_manager_openbsd.cc:173:1: error: unknown type name 'ScopedAudioManagerPtr'
ScopedAudioManagerPtr CreateAudioManager(
^
../../media/audio/openbsd/audio_manager_openbsd.cc:194:10: error: use of undeclared identifier 'ScopedAudioManagerPtr'
  return ScopedAudioManagerPtr(
         ^
3 errors generated.
```
Syncing it with the OpenBSD port should hopefully fix it.

[1] https://chromium.googlesource.com/chromium/src/+/2cbd4fcab300af5aa4ef76752673901d58da0f24